### PR TITLE
feat: add Indeed as supported company

### DIFF
--- a/src/components/ui/matches-card/MatchesCard.tsx
+++ b/src/components/ui/matches-card/MatchesCard.tsx
@@ -5,7 +5,7 @@ import { ProviderRanking } from '../provider-ranking';
 import { MatchTypes } from '../../../types';
 import { PreferencesGrid } from '../preferences-grid';
 import { ApprovalButton } from '../approval-button';
-import { getCompayNameById } from '../../../utils/idMappings';
+import { getCompanyNameById } from '../../../utils/idMappings';
 
 export type MatchesCardProps = {
     isChecked: boolean;
@@ -53,7 +53,7 @@ export const MatchesCard = ({
         >
             <Checkbox data-testid="user-card-checkbox" checked={isChecked} onClick={onCheck} />
             <Box flexGrow="1" style={{ paddingLeft: theme.spacing(3) }}>
-                <TextSmall>{getCompayNameById(companyId)}</TextSmall>
+                <TextSmall>{getCompanyNameById(companyId)}</TextSmall>
                 <Header3>{emailAddress}</Header3>
                 <TextSmall style={{ paddingTop: theme.spacing(1) }}>Provider Preferences</TextSmall>
                 <PreferencesGrid

--- a/src/routes/pages/Matches.tsx
+++ b/src/routes/pages/Matches.tsx
@@ -24,7 +24,7 @@ import { useProvidersApi } from '../../hooks/useProvidersApi';
 import { MatchesList, CreateMatchModal, Navigation } from '../../components';
 import { countMatchQualities } from '../../utils/MatchQuality';
 import { CompanyIds, CompanyNames } from '../../types/company';
-import { getCompayNameById } from '../../utils/idMappings';
+import { getCompanyNameById } from '../../utils/idMappings';
 
 export const Matches = () => {
     const theme = useTheme();
@@ -78,6 +78,7 @@ export const Matches = () => {
             options: [
                 { value: 'all', text: 'all' },
                 { value: CompanyIds.CriticalMass, text: CompanyNames.CriticalMass },
+                { value: CompanyIds.Indeed, text: CompanyNames.Indeed },
                 { value: CompanyIds.Therify, text: CompanyNames.Therify },
                 { value: CompanyIds.Thumbtack, text: CompanyNames.Thumbtack },
             ],
@@ -91,9 +92,9 @@ export const Matches = () => {
     const getNoMatchesMessage = () => {
         let message;
         if (companyFilter !== 'all' && searchTerm !== '') {
-            message = `${searchTerm} in ${getCompayNameById(companyFilter)}`;
+            message = `${searchTerm} in ${getCompanyNameById(companyFilter)}`;
         } else {
-            message = companyFilter !== 'all' ? getCompayNameById(companyFilter) : searchTerm;
+            message = companyFilter !== 'all' ? getCompanyNameById(companyFilter) : searchTerm;
         }
         return message ? `No matches for ${message}` : undefined;
     };

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -2,14 +2,17 @@ export enum CompanyIds {
     'Therify' = '210266712266048',
     'Thumbtack' = '210438722173148',
     'CriticalMass' = '210438357319154',
+    'Indeed' = '211955886693171',
 }
 export enum CompanyNames {
     'Therify' = 'Therify',
     'Thumbtack' = 'Thumbtack',
     'CriticalMass' = 'Critical Mass',
+    'Indeed' = 'Indeed',
 }
 export const CompanyMap: Record<CompanyIds, CompanyNames> = {
+    [CompanyIds.CriticalMass]: CompanyNames.CriticalMass,
+    [CompanyIds.Indeed]: CompanyNames.Indeed,
     [CompanyIds.Therify]: CompanyNames.Therify,
     [CompanyIds.Thumbtack]: CompanyNames.Thumbtack,
-    [CompanyIds.CriticalMass]: CompanyNames.CriticalMass,
 };

--- a/src/utils/idMappings.spec.ts
+++ b/src/utils/idMappings.spec.ts
@@ -1,14 +1,14 @@
 import { CompanyIds, CompanyNames } from '../types/company';
-import { getCompayNameById } from './idMappings';
+import { getCompanyNameById } from './idMappings';
 
 describe('idMappings', () => {
-    describe('getCompayNameById', () => {
+    describe('getCompanyNameById', () => {
         it("should return 'unknown company' if unmatched id provided", () => {
-            expect(getCompayNameById('blahblahblah' as CompanyIds)).toBe('unknown company');
+            expect(getCompanyNameById('blahblahblah' as CompanyIds)).toBe('unknown company');
         });
 
         it('should return company name if recognized id', () => {
-            expect(getCompayNameById(CompanyIds.Therify)).toBe(CompanyNames.Therify);
+            expect(getCompanyNameById(CompanyIds.Therify)).toBe(CompanyNames.Therify);
         });
     });
 });

--- a/src/utils/idMappings.ts
+++ b/src/utils/idMappings.ts
@@ -1,14 +1,5 @@
-import { CompanyIds, CompanyNames } from '../types/company';
+import { CompanyIds, CompanyMap, CompanyNames } from '../types/company';
 
-export const getCompayNameById = (id: string): CompanyNames | 'unknown company' => {
-    switch (id) {
-        case CompanyIds.CriticalMass:
-            return CompanyNames.CriticalMass;
-        case CompanyIds.Therify:
-            return CompanyNames.Therify;
-        case CompanyIds.Thumbtack:
-            return CompanyNames.Thumbtack;
-        default:
-            return 'unknown company';
-    }
+export const getCompanyNameById = (id: string): CompanyNames | 'unknown company' => {
+    return CompanyMap[id as CompanyIds] ?? 'unknown company';
 };


### PR DESCRIPTION
- Adds Indeed as supported company.
- Fixes type for `getCompanyNameById`
- Refactors `getCompanyNameById` logic to index off of company object over switch statement.

<img width="800" alt="Indeed matches screenshot" src="https://user-images.githubusercontent.com/25045075/126005101-58e5e51f-6db0-46c5-a226-d67c9850ac9c.png">