### PR TITLE
feat: add link to provider name in matches card

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     rules: {
         // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
         // e.g. "@typescript-eslint/explicit-function-return-type": "off",
+        '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',

--- a/src/components/ui/matches-card/MatchesCard.spec.tsx
+++ b/src/components/ui/matches-card/MatchesCard.spec.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { MatchesCard } from './MatchesCard';

--- a/src/components/ui/matches-card/MatchesCard.tsx
+++ b/src/components/ui/matches-card/MatchesCard.tsx
@@ -90,7 +90,7 @@ export const MatchesCard = ({
                         rankings.map((ranking, i) => (
                             <ProviderRanking
                                 key={ranking.id}
-                                id={ranking.id}
+                                id={ranking.provider.id}
                                 status={ranking.status}
                                 statusText={ranking.statusReason}
                                 displayText={`${ranking.provider.firstName} ${ranking.provider.lastName}`}

--- a/src/components/ui/provider-ranking/ProviderRanking.tsx
+++ b/src/components/ui/provider-ranking/ProviderRanking.tsx
@@ -1,4 +1,4 @@
-import { Box, Theme, useTheme, withStyles } from '@material-ui/core';
+import { Box, Link, Theme, useTheme, withStyles } from '@material-ui/core';
 import { Delete } from '@material-ui/icons';
 import { MatchTypes } from '../../../types';
 import React from 'react';
@@ -51,7 +51,13 @@ export const ProviderRanking = ({ id, status, rank, displayText, statusText, onD
             >
                 <div style={flexCenter}>
                     {rank && <TextSmall style={{ width: theme.spacing(3), margin: 0 }}>{rank}.</TextSmall>}
-                    <TextBold style={{ margin: 0 }}>{displayText}</TextBold>
+                    <Link
+                        href={`${window.location.origin}/providers/${id}`}
+                        target="_blank"
+                        style={{ color: theme.palette.text.primary }}
+                    >
+                        <TextBold style={{ margin: 0 }}>{displayText}</TextBold>
+                    </Link>
                 </div>
                 {statusText && <Text style={{ margin: 0, color: textColor }}>{statusText}</Text>}
             </Box>


### PR DESCRIPTION
- adds link to provider name in `ProviderRanking`.
- passes `ranking.provider.id` to `ProviderRanking`
- adds `'@typescript-eslint/no-empty-function': 'off'` es-lint rule to fix complaining in some spec files