### PR TITLE
fix(provider-ranking): pass match id and provider id to ranking

### DIFF
--- a/src/components/create-match-modal/CreateMatchModal.tsx
+++ b/src/components/create-match-modal/CreateMatchModal.tsx
@@ -97,6 +97,7 @@ export const CreateMatchModal = ({
                                 <ProviderRanking
                                     data-testid="provider-ranking"
                                     id="selectedProviderStatus"
+                                    providerId={selectedProvider.id}
                                     displayText={(matchCompatibility.reasons ?? []).join(', ')}
                                     status={matchCompatibility.status}
                                 />

--- a/src/components/ui/matches-card/MatchesCard.tsx
+++ b/src/components/ui/matches-card/MatchesCard.tsx
@@ -90,7 +90,8 @@ export const MatchesCard = ({
                         rankings.map((ranking, i) => (
                             <ProviderRanking
                                 key={ranking.id}
-                                id={ranking.provider.id}
+                                id={ranking.id}
+                                providerId={ranking.provider.id}
                                 status={ranking.status}
                                 statusText={ranking.statusReason}
                                 displayText={`${ranking.provider.firstName} ${ranking.provider.lastName}`}

--- a/src/components/ui/provider-ranking/ProviderRanking.stories.tsx
+++ b/src/components/ui/provider-ranking/ProviderRanking.stories.tsx
@@ -7,6 +7,7 @@ export const PatientCard: Story = () => {
     return (
         <ProviderRankingUi
             id="test"
+            providerId="test"
             onDelete={async () => alert('Deleted!')}
             rank={1}
             displayText="Dr. Test Jenkins"
@@ -18,6 +19,7 @@ export const Warning: Story = () => {
     return (
         <ProviderRankingUi
             id="tests"
+            providerId="test"
             rank={1}
             displayText="Dr. Test Jenkins"
             statusText="Gender: Male"
@@ -30,6 +32,7 @@ export const Incompatible: Story = () => {
     return (
         <ProviderRankingUi
             id="test"
+            providerId="test"
             rank={1}
             displayText="Dr. Test Jenkins"
             statusText="Out of Network"
@@ -40,12 +43,25 @@ export const Incompatible: Story = () => {
 };
 export const NoDelete: Story = () => {
     return (
-        <ProviderRankingUi id="test" rank={1} displayText="Dr. Test Jenkins" status={MatchTypes.RankingStatus.GOOD} />
+        <ProviderRankingUi
+            id="test"
+            providerId="test"
+            rank={1}
+            displayText="Dr. Test Jenkins"
+            status={MatchTypes.RankingStatus.GOOD}
+        />
     );
 };
 
 export const NoRank: Story = () => {
-    return <ProviderRankingUi id="test" displayText="Dr. Test Jenkins" status={MatchTypes.RankingStatus.GOOD} />;
+    return (
+        <ProviderRankingUi
+            id="test"
+            providerId="test"
+            displayText="Dr. Test Jenkins"
+            status={MatchTypes.RankingStatus.GOOD}
+        />
+    );
 };
 
 export default {

--- a/src/components/ui/provider-ranking/ProviderRanking.tsx
+++ b/src/components/ui/provider-ranking/ProviderRanking.tsx
@@ -6,6 +6,7 @@ import { Text, TextSmall, TextBold } from '../../ui';
 
 export type ProviderRankingProps = {
     id: string;
+    providerId: string;
     status: MatchTypes.RankingStatus;
     rank?: number;
     displayText: string;
@@ -33,7 +34,15 @@ const getStatusColor = ({ theme, status }: { status: MatchTypes.RankingStatus; t
             };
     }
 };
-export const ProviderRanking = ({ id, status, rank, displayText, statusText, onDelete }: ProviderRankingProps) => {
+export const ProviderRanking = ({
+    id,
+    providerId,
+    status,
+    rank,
+    displayText,
+    statusText,
+    onDelete,
+}: ProviderRankingProps) => {
     const theme = useTheme();
     const { backgroundColor, textColor } = getStatusColor({ theme, status });
     return (
@@ -52,7 +61,7 @@ export const ProviderRanking = ({ id, status, rank, displayText, statusText, onD
                 <div style={flexCenter}>
                     {rank && <TextSmall style={{ width: theme.spacing(3), margin: 0 }}>{rank}.</TextSmall>}
                     <Link
-                        href={`${window.location.origin}/providers/${id}`}
+                        href={`${window.location.origin}/providers/${providerId}`}
                         target="_blank"
                         style={{ color: theme.palette.text.primary }}
                     >


### PR DESCRIPTION
Bug: we received 404 errors when trying to remove a provider from a match card.

Cause: the id passed to the ranking component is used in the `delete` server call. When that id got switched from the ranking id to the provider id in [this pr](https://github.com/Therify/admin-ui/pull/13), the id no longer was recognized server side.

fix: Add `providerId` prop to the ranking to use in the URL link. Keep `id` prop scoped to the ranking id.