### PR TITLE
feat:add timestamps to match card

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeProvider, CssBaseline } from '@material-ui/core';
-import { therifyTheme } from '../src/components/core/theme';
+import { therifyTheme } from '../src/components';
 
 export const parameters = {
     actions: { argTypesRegex: '^on[A-Z].*' },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "axios": "^0.21.1",
         "babel-loader": "8.1.0",
         "csvtojson": "^2.0.10",
+        "date-fns": "^2.23.0",
         "deep-equal": "^2.0.5",
         "formik": "^2.2.9",
         "formik-material-ui": "^3.0.1",
@@ -62,7 +63,8 @@
         "build": "react-scripts build",
         "test": "react-scripts test --watchAll=false",
         "eject": "react-scripts eject",
-        "prettify": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,css,scss}\" --ignore-path .gitignore"
+        "prettify": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,css,scss}\" --ignore-path .gitignore",
+        "storybook": "start-storybook -p 6006"
     },
     "eslintConfig": {
         "extends": [

--- a/src/api/utils/matchesHelpers.ts
+++ b/src/api/utils/matchesHelpers.ts
@@ -38,6 +38,7 @@ const groupMatchRecordsByUser = (matchRecords: MatchRecord[]): MatchTypes.Match[
         } else {
             map[record.user!.details.id] = {
                 user: record.user!.details,
+                created: new Date(record.match!.created).getTime(),
                 matches: [createMatch(record.match!, record.provider!)],
             };
         }

--- a/src/components/matches-list/MatchesList.tsx
+++ b/src/components/matches-list/MatchesList.tsx
@@ -79,6 +79,7 @@ export const MatchesList = ({
                     onCheck={() => onCheck(match.user.id)}
                     user={match.user}
                     rankings={match.matches}
+                    receivedDate={match.created}
                     handleApprove={() => handleApprove(match.user.id)}
                     handleDeleteMatch={handleDeleteMatch}
                     handleCreateMatch={() => handleCreateMatch(match)}

--- a/src/components/ui/date-chip/DateChip.spec.tsx
+++ b/src/components/ui/date-chip/DateChip.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { DateChip } from './DateChip';
-import { format, addBusinessDays } from 'date-fns';
+import { format, addBusinessDays, subBusinessDays } from 'date-fns';
 import '@testing-library/jest-dom/extend-expect';
 
 describe('MatchCounter', () => {
@@ -17,5 +17,11 @@ describe('MatchCounter', () => {
         const { getByText } = render(<DateChip type="due" date={date} />);
         const chipDate = getByText(format(addBusinessDays(date, 2), 'MM/dd'));
         expect(chipDate).toBeInTheDocument();
+    });
+
+    it('shows alert icon when due date is today', () => {
+        const { getByTestId } = render(<DateChip type="due" date={subBusinessDays(date, 2)} />);
+        const alertIcon = getByTestId('priority-high-icon');
+        expect(alertIcon).toBeInTheDocument();
     });
 });

--- a/src/components/ui/date-chip/DateChip.spec.tsx
+++ b/src/components/ui/date-chip/DateChip.spec.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DateChip } from './DateChip';
+import { format, addBusinessDays } from 'date-fns';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('MatchCounter', () => {
+    const date = new Date().getTime();
+
+    it('displays date when type is `received`', () => {
+        const { getByText } = render(<DateChip type="received" date={date} />);
+        const chipDate = getByText(format(date, 'MM/dd'));
+        expect(chipDate).toBeInTheDocument();
+    });
+
+    it('adds 2 business days to date when type is `due`', () => {
+        const { getByText } = render(<DateChip type="due" date={date} />);
+        const chipDate = getByText(format(addBusinessDays(date, 2), 'MM/dd'));
+        expect(chipDate).toBeInTheDocument();
+    });
+});

--- a/src/components/ui/date-chip/DateChip.stories.tsx
+++ b/src/components/ui/date-chip/DateChip.stories.tsx
@@ -1,0 +1,11 @@
+import { Meta, Story } from '@storybook/react/types-6-0';
+import React from 'react';
+import { DateChip as DateChipUi, DateChipProps } from './DateChip';
+
+export const ReceivedDateChip: Story<DateChipProps> = () => <DateChipUi type="received" date={new Date().getTime()} />;
+
+export const DueDateChip: Story<DateChipProps> = () => <DateChipUi type="due" date={new Date().getTime()} />;
+
+export default {
+    title: 'Ui/DateChip',
+} as Meta;

--- a/src/components/ui/date-chip/DateChip.stories.tsx
+++ b/src/components/ui/date-chip/DateChip.stories.tsx
@@ -1,10 +1,15 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React from 'react';
+import { subBusinessDays } from 'date-fns';
 import { DateChip as DateChipUi, DateChipProps } from './DateChip';
 
 export const ReceivedDateChip: Story<DateChipProps> = () => <DateChipUi type="received" date={new Date().getTime()} />;
 
 export const DueDateChip: Story<DateChipProps> = () => <DateChipUi type="due" date={new Date().getTime()} />;
+
+export const DueTodayDateChip: Story<DateChipProps> = () => (
+    <DateChipUi type="due" date={subBusinessDays(new Date().getTime(), 2)} />
+);
 
 export default {
     title: 'Ui/DateChip',

--- a/src/components/ui/date-chip/DateChip.tsx
+++ b/src/components/ui/date-chip/DateChip.tsx
@@ -29,7 +29,7 @@ export const DateChip = ({ type, date }: DateChipProps) => {
         <Chip
             title={type === 'due' ? 'Due Date' : 'Received date'}
             icon={getIcon(type, isDueToday)}
-            label={format(displayDate, 'MM/dd')}
+            label={`${type === 'due' ? 'Due: ' : ''}${format(displayDate, 'MM/dd')}`}
             color={type === 'due' ? 'primary' : undefined}
             style={{ marginRight: spacing(1), backgroundColor: isDueToday ? palette.error.main : undefined }}
         />

--- a/src/components/ui/date-chip/DateChip.tsx
+++ b/src/components/ui/date-chip/DateChip.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { CallReceived, Schedule } from '@material-ui/icons';
+import { Chip } from '@material-ui/core';
+import { format, addBusinessDays } from 'date-fns';
+
+const ICON_FONT_SIZE = '14px';
+
+export interface DateChipProps {
+    date: number | Date | string;
+    type: 'received' | 'due';
+}
+
+const getIcon = (dateType: 'received' | 'due') => {
+    switch (dateType) {
+        case 'received':
+            return <CallReceived style={{ fontSize: ICON_FONT_SIZE }} />;
+        default:
+            return <Schedule style={{ fontSize: ICON_FONT_SIZE }} />;
+    }
+};
+export const DateChip = ({ type, date }: DateChipProps) => {
+    const displayDate = type === 'due' ? addBusinessDays(new Date(date), 2) : new Date(date);
+    return (
+        <Chip
+            icon={getIcon(type)}
+            label={format(displayDate, 'MM/dd')}
+            color={type === 'due' ? 'primary' : undefined}
+        />
+    );
+};

--- a/src/components/ui/date-chip/DateChip.tsx
+++ b/src/components/ui/date-chip/DateChip.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
-import { CallReceived, Schedule } from '@material-ui/icons';
-import { Chip } from '@material-ui/core';
-import { format, addBusinessDays } from 'date-fns';
+import { CallReceived, Schedule, PriorityHigh } from '@material-ui/icons';
+import { Chip, useTheme } from '@material-ui/core';
+import { format, addBusinessDays, isToday, isAfter } from 'date-fns';
 
 const ICON_FONT_SIZE = '14px';
 
 export interface DateChipProps {
-    date: number | Date | string;
+    date: number | Date;
     type: 'received' | 'due';
 }
 
-const getIcon = (dateType: 'received' | 'due') => {
+const getIcon = (dateType: 'received' | 'due', isDueToday: boolean) => {
+    if (isDueToday) {
+        return <PriorityHigh data-test-id="priority-high-icon" style={{ fontSize: ICON_FONT_SIZE }} />;
+    }
     switch (dateType) {
         case 'received':
             return <CallReceived style={{ fontSize: ICON_FONT_SIZE }} />;
@@ -19,13 +22,16 @@ const getIcon = (dateType: 'received' | 'due') => {
     }
 };
 export const DateChip = ({ type, date }: DateChipProps) => {
-    const displayDate = type === 'due' ? addBusinessDays(new Date(date), 2) : new Date(date);
+    const displayDate = type === 'due' ? addBusinessDays(date, 2) : date;
+    const isDueToday = type === 'due' && (isToday(displayDate) || isAfter(new Date(), displayDate));
+    const { spacing, palette } = useTheme();
     return (
         <Chip
             title={type === 'due' ? 'Due Date' : 'Received date'}
-            icon={getIcon(type)}
+            icon={getIcon(type, isDueToday)}
             label={format(displayDate, 'MM/dd')}
             color={type === 'due' ? 'primary' : undefined}
+            style={{ marginRight: spacing(1), backgroundColor: isDueToday ? palette.error.main : undefined }}
         />
     );
 };

--- a/src/components/ui/date-chip/DateChip.tsx
+++ b/src/components/ui/date-chip/DateChip.tsx
@@ -22,6 +22,7 @@ export const DateChip = ({ type, date }: DateChipProps) => {
     const displayDate = type === 'due' ? addBusinessDays(new Date(date), 2) : new Date(date);
     return (
         <Chip
+            title={type === 'due' ? 'Due Date' : 'Received date'}
             icon={getIcon(type)}
             label={format(displayDate, 'MM/dd')}
             color={type === 'due' ? 'primary' : undefined}

--- a/src/components/ui/date-chip/index.ts
+++ b/src/components/ui/date-chip/index.ts
@@ -1,0 +1,1 @@
+export * from './DateChip';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,6 +1,7 @@
 export * from './core';
 export * from './layout';
 export * from './alert';
+export * from './date-chip';
 export * from './select-group';
 export * from './match-counter';
 export * from './matches-card';

--- a/src/components/ui/matches-card/MatchesCard.spec.tsx
+++ b/src/components/ui/matches-card/MatchesCard.spec.tsx
@@ -8,6 +8,7 @@ describe('MatchesCard', () => {
     it('should render patient data', () => {
         const { getByText } = render(
             <MatchesCard
+                receivedDate={new Date()}
                 handleApprove={async () => {}}
                 isChecked={false}
                 onCheck={() => {}}
@@ -28,6 +29,7 @@ describe('MatchesCard', () => {
         const handleCheck = jest.fn();
         const { getByTestId } = render(
             <MatchesCard
+                receivedDate={new Date()}
                 isChecked={false}
                 onCheck={handleCheck}
                 user={Mocks.mockUser}
@@ -43,6 +45,7 @@ describe('MatchesCard', () => {
     it('should render approval button when approvable rankings present', () => {
         const { getByText } = render(
             <MatchesCard
+                receivedDate={new Date()}
                 isChecked={false}
                 onCheck={() => {}}
                 user={Mocks.mockUser}
@@ -57,6 +60,7 @@ describe('MatchesCard', () => {
     it('should NOT render approval button when no approvable rankings present', () => {
         const { getByText } = render(
             <MatchesCard
+                receivedDate={new Date()}
                 isChecked={false}
                 onCheck={() => {}}
                 user={Mocks.mockUser}

--- a/src/components/ui/matches-card/MatchesCard.stories.tsx
+++ b/src/components/ui/matches-card/MatchesCard.stories.tsx
@@ -12,6 +12,7 @@ export const MatchesCard: Story = () => {
     const [isChecked, setIsChecked] = useState(false);
     return (
         <MatchesCardUi
+            receivedDate={new Date()}
             isChecked={isChecked}
             onCheck={() => setIsChecked(!isChecked)}
             user={Mocks.mockUser}
@@ -30,6 +31,7 @@ export const NoMatchCreation: Story = () => {
     const [isChecked, setIsChecked] = useState(false);
     return (
         <MatchesCardUi
+            receivedDate={new Date()}
             isChecked={isChecked}
             onCheck={() => setIsChecked(!isChecked)}
             user={Mocks.mockUser}
@@ -48,6 +50,7 @@ export const NoApprovableMatches: Story = () => {
     const [isChecked, setIsChecked] = useState(false);
     return (
         <MatchesCardUi
+            receivedDate={new Date()}
             isChecked={isChecked}
             onCheck={() => setIsChecked(!isChecked)}
             user={Mocks.mockUser}
@@ -78,6 +81,7 @@ export const NoMatchesToShow: Story = () => {
     const [isChecked, setIsChecked] = useState(false);
     return (
         <MatchesCardUi
+            receivedDate={new Date()}
             isChecked={isChecked}
             onCheck={() => setIsChecked(!isChecked)}
             user={Mocks.mockUser}

--- a/src/components/ui/matches-card/MatchesCard.tsx
+++ b/src/components/ui/matches-card/MatchesCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Paper, Theme, useTheme, withStyles } from '@material-ui/core';
-import { Checkbox, TextSmall, Text, Header3 } from '../../ui';
+import { Checkbox, TextSmall, Text, Header3, DateChip } from '../../ui';
 import { ProviderRanking } from '../provider-ranking';
 import { MatchTypes } from '../../../types';
 import { PreferencesGrid } from '../preferences-grid';
@@ -11,6 +11,7 @@ export type MatchesCardProps = {
     isChecked: boolean;
     onCheck: () => void;
     user: MatchTypes.User;
+    receivedDate: number | Date;
     rankings: (MatchTypes.Ranking & {
         status: MatchTypes.RankingStatus;
         statusReason?: string;
@@ -25,6 +26,7 @@ export const MatchesCard = ({
     onCheck,
     user,
     rankings,
+    receivedDate,
     handleApprove,
     handleCancelApprove,
     handleDeleteMatch,
@@ -63,6 +65,10 @@ export const MatchesCard = ({
                     issues={(issues ?? []).join(', ')}
                     insuranceProvider={insuranceProvider}
                 />
+                <Box display="flex" alignItems="center">
+                    <DateChip type="received" date={receivedDate} />
+                    <DateChip type="due" date={receivedDate} />
+                </Box>
             </Box>
             <Box style={{ width: '45%' }}>
                 <Box

--- a/src/types/api/matchApi.ts
+++ b/src/types/api/matchApi.ts
@@ -35,6 +35,8 @@ export interface IMatch {
     type: ResponseType.Match;
     criteria: Record<string, MatchPreferenceQualifier>;
     score: number;
+    created: string;
+    modified: string;
 }
 
 interface RecordData {

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -1,6 +1,7 @@
 import { CompanyIds } from './company';
 import { Gender } from './types';
 export type Match = {
+    created: number;
     user: User;
     matches: Ranking[];
 };

--- a/src/types/mocks/rankingResult.ts
+++ b/src/types/mocks/rankingResult.ts
@@ -13,6 +13,7 @@ export const mockRanking: Ranking = {
 
 export const mockModelResult: Match = {
     user: mockUser,
+    created: new Date().getTime(),
     matches: [
         {
             ...mockRanking,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6441,6 +6441,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
+  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
- Adds `DateChip` ui element
- Adds `created` field to match record
- Adds `date-fns` as dependency (for due date logic)
- fixes storybook theme import and adds storybook start script